### PR TITLE
Functional tests for pmm-admin cmd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,15 @@ go:
   - 1.7.x
   - 1.8.x
 
+services:
+  - mysql
+
 notifications:
   email: false
 
 script:
-  - go get github.com/kardianos/govendor
-  - govendor sync
-  - go test -v ./pmm
+  # Magical command `go list ./... | grep -v /vendor/` is required to skip vendor folder when using `./...` pattern
+  # https://github.com/golang/go/issues/19090
+  - pkgs=$(go list ./... | grep -v /vendor/)
+  - go test -v $pkgs
+  - go build -o bin/pmm-admin

--- a/pmm-admin.go
+++ b/pmm-admin.go
@@ -925,8 +925,11 @@ func main() {
 	cmdRestart.Flags().BoolVar(&flagAll, "all", false, "restart all monitoring services")
 
 	if os.Getuid() != 0 {
-		fmt.Println("pmm-admin requires superuser privileges to manage system services.")
-		os.Exit(1)
+		// skip root check if binary was build in tests
+		if pmm.Version != "gotest" {
+			fmt.Println("pmm-admin requires superuser privileges to manage system services.")
+			os.Exit(1)
+		}
 	}
 
 	if err := rootCmd.Execute(); err != nil {

--- a/pmm-admin_test.go
+++ b/pmm-admin_test.go
@@ -1,0 +1,173 @@
+/*
+	Copyright (c) 2016, Percona LLC and/or its affiliates. All rights reserved.
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/percona/pmm-client/pmm"
+	"github.com/percona/pmm-client/test/cmdtest"
+	"github.com/percona/pmm-client/test/fakeapi"
+	"github.com/stretchr/testify/assert"
+)
+
+type pmmAdminData struct {
+	bin     string
+	basedir string
+}
+
+func TestPmmAdmin(t *testing.T) {
+	var err error
+
+	// We can't/shouldn't use /usr/local/percona/ (the default basedir), so use
+	// a tmpdir instead with roughly the same structure.
+	basedir, err := ioutil.TempDir("/tmp", "pmm-client-test-basedir-")
+	assert.Nil(t, err)
+	defer func() {
+		err := os.RemoveAll(basedir)
+		assert.Nil(t, err)
+	}()
+
+	bindir, err := ioutil.TempDir("/tmp", "pmm-client-test-bindir-")
+	assert.Nil(t, err)
+	defer func() {
+		err := os.RemoveAll(bindir)
+		assert.Nil(t, err)
+	}()
+
+	bin := bindir + "/pmm-admin"
+	pmmBaseDir := basedir + "/pmm-client"
+	agentBaseDir := basedir + "/qan-agent"
+	xVariables := map[string]string{
+		"github.com/percona/pmm-client/pmm.Version":      "gotest",
+		"github.com/percona/pmm-client/pmm.PMMBaseDir":   pmmBaseDir,
+		"github.com/percona/pmm-client/pmm.AgentBaseDir": agentBaseDir,
+	}
+	var ldflags []string
+	for x, value := range xVariables {
+		ldflags = append(ldflags, fmt.Sprintf("-X %s=%s", x, value))
+	}
+	cmd := exec.Command(
+		"go",
+		"build",
+		"-o",
+		bin,
+		"-ldflags",
+		strings.Join(ldflags, " "),
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	assert.Nil(t, err, "Failed to build: %s", err)
+
+	data := pmmAdminData{
+		bin:     bin,
+		basedir: basedir,
+	}
+	tests := []func(*testing.T, pmmAdminData){
+		testVersion,
+		testConfig,
+	}
+	t.Run("pmm-admin", func(t *testing.T) {
+		for _, f := range tests {
+			f := f // capture range variable
+			fName := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+			t.Run(fName, func(t *testing.T) {
+				// t.Parallel()
+				f(t, data)
+			})
+		}
+	})
+
+}
+
+func testVersion(t *testing.T, data pmmAdminData) {
+	defer func() {
+		err := os.RemoveAll(data.basedir)
+		assert.Nil(t, err)
+	}()
+
+	cmd := exec.Command(
+		data.bin,
+		"--version",
+	)
+
+	cmdTest := cmdtest.New(cmd)
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+	err := cmd.Wait()
+	assert.Nil(t, err)
+
+	// sanity check that version number was changed with ldflag for this test build
+	assert.Equal(t, "EXPERIMENTAL", pmm.Version)
+	assert.Equal(t, "gotest\n", cmdTest.ReadLine())
+
+	assert.Equal(t, "", cmdTest.ReadLine()) // No more data
+}
+
+func testConfig(t *testing.T, data pmmAdminData) {
+	defer func() {
+		err := os.RemoveAll(data.basedir)
+		assert.Nil(t, err)
+	}()
+
+	os.MkdirAll(data.basedir+"/pmm-client", 0777)
+
+	// Create fake api server
+	api := fakeapi.New()
+	u, _ := url.Parse(api.URL())
+	clientAddress, _, _ := net.SplitHostPort(u.Host)
+	clientName, _ := os.Hostname()
+	api.AppendRoot()
+	api.AppendConsulV1StatusLeader(clientAddress)
+	api.AppendConsulV1CatalogNode()
+
+	cmd := exec.Command(
+		data.bin,
+		"config",
+		"--server",
+		u.Host,
+	)
+
+	cmdTest := cmdtest.New(cmd)
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+	err := cmd.Wait()
+	assert.Nil(t, err)
+
+	// sanity check that version number was changed with ldflag for this test build
+	assert.Equal(t, "OK, PMM server is alive.\n", cmdTest.ReadLine())
+	assert.Equal(t, "\n", cmdTest.ReadLine())
+	assert.Equal(t, fmt.Sprintf("%-15s | %s \n", "PMM Server", u.Host), cmdTest.ReadLine())
+	assert.Equal(t, fmt.Sprintf("%-15s | %s\n", "Client Name", clientName), cmdTest.ReadLine())
+	assert.Equal(t, fmt.Sprintf("%-15s | %s \n", "Client Address", clientAddress), cmdTest.ReadLine())
+
+	assert.Equal(t, "", cmdTest.ReadLine()) // No more data
+}

--- a/pmm/config.go
+++ b/pmm/config.go
@@ -257,7 +257,7 @@ What ports to map you can find from "pmm-admin check-network" output once you ad
 	}
 
 	// If agent config exists, update the options like address, SSL, password etc.
-	agentConfigFile := fmt.Sprintf("%s/config/agent.conf", agentBaseDir)
+	agentConfigFile := fmt.Sprintf("%s/config/agent.conf", AgentBaseDir)
 	if FileExists(agentConfigFile) {
 		if err := a.syncAgentConfig(agentConfigFile); err != nil {
 			return fmt.Errorf("Unable to update agent config %s: %s", agentConfigFile, err)
@@ -426,7 +426,7 @@ func (a *Admin) deregisterNode(name string) error {
 
 // renameInstance renames instance with given uuid
 func (a *Admin) renameInstance(instanceUUID, oldName, newName string) error {
-	bytes, err := ioutil.ReadFile(fmt.Sprintf("%s/instance/%s.json", agentBaseDir, instanceUUID))
+	bytes, err := ioutil.ReadFile(fmt.Sprintf("%s/instance/%s.json", AgentBaseDir, instanceUUID))
 	if err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func (a *Admin) renameInstance(instanceUUID, oldName, newName string) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(fmt.Sprintf("%s/instance/%s.json", agentBaseDir, instanceUUID), newBytes, 0600); err != nil {
+	if err := ioutil.WriteFile(fmt.Sprintf("%s/instance/%s.json", AgentBaseDir, instanceUUID), newBytes, 0600); err != nil {
 		return err
 	}
 

--- a/pmm/constants.go
+++ b/pmm/constants.go
@@ -24,8 +24,6 @@ import (
 )
 
 const (
-	PMMBaseDir     = "/usr/local/percona/pmm-client"
-	agentBaseDir   = "/usr/local/percona/qan-agent" // This is also hardcoded in mysql_queries.go
 	qanAPIBasePath = "qan-api"
 	noMonitoring   = "No monitoring registered for this node identified as"
 	apiTimeout     = 30 * time.Second
@@ -33,7 +31,11 @@ const (
 )
 
 var (
-	Version     = "EXPERIMENTAL"
+	Version = "EXPERIMENTAL"
+
+	PMMBaseDir   = "/usr/local/percona/pmm-client"
+	AgentBaseDir = "/usr/local/percona/qan-agent"
+
 	ConfigFile  = fmt.Sprintf("%s/pmm.yml", PMMBaseDir)
 	SSLCertFile = fmt.Sprintf("%s/server.crt", PMMBaseDir)
 	SSLKeyFile  = fmt.Sprintf("%s/server.key", PMMBaseDir)

--- a/pmm/list.go
+++ b/pmm/list.go
@@ -152,7 +152,7 @@ func (a *Admin) List() error {
 					case "dsn":
 						dsn = string(kvp.Value)
 					case "qan_mysql_uuid":
-						f := fmt.Sprintf("%s/config/qan-%s.conf", agentBaseDir, kvp.Value)
+						f := fmt.Sprintf("%s/config/qan-%s.conf", AgentBaseDir, kvp.Value)
 						querySource, _ := getQuerySource(f)
 						opts = append(opts, fmt.Sprintf("query_source=%s", querySource))
 						queryExamples, _ := getQueryExamples(f)

--- a/pmm/main.go
+++ b/pmm/main.go
@@ -650,8 +650,8 @@ func CheckBinaries() string {
 		fmt.Sprintf("%s/mysqld_exporter", PMMBaseDir),
 		fmt.Sprintf("%s/mongodb_exporter", PMMBaseDir),
 		fmt.Sprintf("%s/proxysql_exporter", PMMBaseDir),
-		fmt.Sprintf("%s/bin/percona-qan-agent", agentBaseDir),
-		fmt.Sprintf("%s/bin/percona-qan-agent-installer", agentBaseDir),
+		fmt.Sprintf("%s/bin/percona-qan-agent", AgentBaseDir),
+		fmt.Sprintf("%s/bin/percona-qan-agent-installer", AgentBaseDir),
 	}
 	for _, p := range paths {
 		if !FileExists(p) {

--- a/pmm/mysql.go
+++ b/pmm/mysql.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 
 	"github.com/percona/go-mysql/dsn"
 )

--- a/pmm/mysql_queries.go
+++ b/pmm/mysql_queries.go
@@ -25,9 +25,9 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 
 	consul "github.com/hashicorp/consul/api"
 	"github.com/percona/kardianos-service"
@@ -57,7 +57,7 @@ func (a *Admin) AddMySQLQueries(info map[string]string) error {
 	}
 
 	// Register agent if config file does not exist.
-	agentConfigFile := fmt.Sprintf("%s/config/agent.conf", agentBaseDir)
+	agentConfigFile := fmt.Sprintf("%s/config/agent.conf", AgentBaseDir)
 	if !FileExists(agentConfigFile) {
 		if err := a.registerAgent(); err != nil {
 			return err
@@ -104,7 +104,7 @@ func (a *Admin) AddMySQLQueries(info map[string]string) error {
 	// Write mysql instance config for qan-agent with real DSN.
 	mysqlInstance.DSN = info["dsn"]
 	bytes, _ := json.MarshalIndent(mysqlInstance, "", "    ")
-	if err := ioutil.WriteFile(fmt.Sprintf("%s/instance/%s.json", agentBaseDir, mysqlInstance.UUID), bytes, 0600); err != nil {
+	if err := ioutil.WriteFile(fmt.Sprintf("%s/instance/%s.json", AgentBaseDir, mysqlInstance.UUID), bytes, 0600); err != nil {
 		return err
 	}
 
@@ -118,7 +118,7 @@ func (a *Admin) AddMySQLQueries(info map[string]string) error {
 			Name:        fmt.Sprintf("pmm-mysql-queries-%d", port),
 			DisplayName: "PMM Query Analytics agent",
 			Description: "PMM Query Analytics agent",
-			Executable:  fmt.Sprintf("%s/bin/percona-qan-agent", agentBaseDir),
+			Executable:  fmt.Sprintf("%s/bin/percona-qan-agent", AgentBaseDir),
 		}
 		if err := installService(svcConfig); err != nil {
 			return err
@@ -205,7 +205,7 @@ func (a *Admin) RemoveMySQLQueries() error {
 	mysqlUUID := string(data.Value)
 
 	// Stop QAN for this MySQL instance on the local agent.
-	agentConfigFile := fmt.Sprintf("%s/config/agent.conf", agentBaseDir)
+	agentConfigFile := fmt.Sprintf("%s/config/agent.conf", AgentBaseDir)
 	agentID, err := getAgentID(agentConfigFile)
 	if err != nil {
 		return err
@@ -429,8 +429,8 @@ func (a *Admin) registerAgent() error {
 	os.RemoveAll("/usr/local/percona/qan-agent/data")
 	os.RemoveAll("/usr/local/percona/qan-agent/instance")
 
-	path := fmt.Sprintf("%s/bin/percona-qan-agent-installer", agentBaseDir)
-	args := []string{"-basedir", agentBaseDir, "-mysql=false"}
+	path := fmt.Sprintf("%s/bin/percona-qan-agent-installer", AgentBaseDir)
+	args := []string{"-basedir", AgentBaseDir, "-mysql=false"}
 	if a.Config.ServerSSL {
 		args = append(args, "-use-ssl")
 	}

--- a/pmm/service.go
+++ b/pmm/service.go
@@ -18,8 +18,40 @@
 package pmm
 
 import (
-	"github.com/percona/kardianos-service"
+	service "github.com/percona/kardianos-service"
 )
+
+var (
+	NewService func(i service.Interface, c *service.Config) (service.Service, error) = service.New
+)
+
+// @todo don't use singleton init, use dependency injection
+func init() {
+	// if we build app in tests then let's mock service installer
+	if Version == "gotest" {
+		NewService = func(i service.Interface, c *service.Config) (service.Service, error) {
+			return &dummyService{}, nil
+		}
+	}
+}
+
+type dummyService struct {
+}
+
+func (*dummyService) Run() error       { return nil }
+func (*dummyService) Start() error     { return nil }
+func (*dummyService) Stop() error      { return nil }
+func (*dummyService) Restart() error   { return nil }
+func (*dummyService) Install() error   { return nil }
+func (*dummyService) Uninstall() error { return nil }
+func (*dummyService) Status() error    { return nil }
+func (*dummyService) Logger(errs chan<- error) (service.Logger, error) {
+	return service.ConsoleLogger, nil
+}
+func (*dummyService) SystemLogger(errs chan<- error) (service.Logger, error) {
+	return service.ConsoleLogger, nil
+}
+func (*dummyService) String() string { return "" }
 
 // Platform service manager handlers.
 type program struct{}
@@ -38,7 +70,7 @@ func (p *program) run() error {
 
 func installService(svcConfig *service.Config) error {
 	prg := &program{}
-	svc, err := service.New(prg, svcConfig)
+	svc, err := NewService(prg, svcConfig)
 	if err != nil {
 		return err
 	}
@@ -54,7 +86,7 @@ func installService(svcConfig *service.Config) error {
 func uninstallService(name string) error {
 	prg := &program{}
 	svcConfig := &service.Config{Name: name}
-	svc, err := service.New(prg, svcConfig)
+	svc, err := NewService(prg, svcConfig)
 	if err != nil {
 		return err
 	}
@@ -72,7 +104,7 @@ func uninstallService(name string) error {
 func startService(name string) error {
 	prg := &program{}
 	svcConfig := &service.Config{Name: name}
-	svc, err := service.New(prg, svcConfig)
+	svc, err := NewService(prg, svcConfig)
 	if err != nil {
 		return err
 	}
@@ -87,7 +119,7 @@ func startService(name string) error {
 func stopService(name string) error {
 	prg := &program{}
 	svcConfig := &service.Config{Name: name}
-	svc, err := service.New(prg, svcConfig)
+	svc, err := NewService(prg, svcConfig)
 	if err != nil {
 		return err
 	}
@@ -102,7 +134,7 @@ func stopService(name string) error {
 func getServiceStatus(name string) bool {
 	prg := &program{}
 	svcConfig := &service.Config{Name: name}
-	svc, err := service.New(prg, svcConfig)
+	svc, err := NewService(prg, svcConfig)
 	if err != nil {
 		return false
 	}

--- a/test/cmdtest/cmdtest.go
+++ b/test/cmdtest/cmdtest.go
@@ -1,0 +1,106 @@
+/*
+   Copyright (c) 2016, Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package cmdtest
+
+import (
+	"bytes"
+	"io"
+	"os/exec"
+	"time"
+)
+
+type CmdTest struct {
+	reader io.Reader
+	stdin  io.Writer
+	output <-chan string
+}
+
+func New(cmd *exec.Cmd) *CmdTest {
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		panic(err)
+	}
+	pipeReader, pipeWriter := io.Pipe()
+	cmd.Stdout = pipeWriter
+	cmd.Stderr = pipeWriter
+
+	cmdOutput := &CmdTest{
+		reader: pipeReader,
+		stdin:  stdin,
+	}
+	cmdOutput.output = cmdOutput.Run()
+	return cmdOutput
+}
+
+func (c *CmdTest) Run() <-chan string {
+	output := make(chan string, 1024)
+	go func() {
+		for {
+			b := make([]byte, 8192)
+			n, err := c.reader.Read(b)
+			if n > 0 {
+				lines := bytes.SplitAfter(b[:n], []byte("\n"))
+				// Example: Split(a\nb\n\c\n) => ["a\n", "b\n", "c\n", ""]
+				// We are getting empty element because data for split was ending with delimiter (\n)
+				// We don't want it, so we remove it
+				lastPos := len(lines) - 1
+				if len(lines[lastPos]) == 0 {
+					lines = lines[:lastPos]
+				}
+				for i := range lines {
+					line := string(lines[i])
+					//log.Printf("%#v", line)
+					output <- line
+				}
+			}
+			if err != nil {
+				break
+			}
+		}
+	}()
+	return output
+}
+
+func (c *CmdTest) ReadLine() (line string) {
+	select {
+	case line = <-c.output:
+	case <-time.After(200 * time.Millisecond):
+	}
+	return line
+}
+
+func (c *CmdTest) Write(data string) {
+	_, err := c.stdin.Write([]byte(data))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (c *CmdTest) Output() []string {
+	lines := []string{}
+
+	for {
+		line := c.ReadLine()
+		if line == "" {
+			break
+		}
+		lines = append(lines, line)
+	}
+
+	return lines
+}

--- a/test/cmdtest/cmdtest_test.go
+++ b/test/cmdtest/cmdtest_test.go
@@ -1,0 +1,95 @@
+/*
+	Copyright (c) 2016, Percona LLC and/or its affiliates. All rights reserved.
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package cmdtest
+
+import (
+	"context"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPmmAdmin(t *testing.T) {
+	var err error
+
+	bindir, err := ioutil.TempDir("/tmp", "pmm-client-test-bindir-")
+	assert.Nil(t, err)
+	defer func() {
+		err := os.RemoveAll(bindir)
+		assert.Nil(t, err)
+	}()
+
+	bin := bindir + "/examplecmd"
+	cmd := exec.Command(
+		"go",
+		"build",
+		"-o",
+		bin,
+		"./examplecmd",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	assert.Nil(t, err, "Failed to build: %s", err)
+
+	tests := []func(*testing.T, string){
+		testInteractive,
+	}
+	t.Run("pmm-admin", func(t *testing.T) {
+		for _, f := range tests {
+			f := f // capture range variable
+			fName := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+			t.Run(fName, func(t *testing.T) {
+				// t.Parallel()
+				f(t, bin)
+			})
+		}
+	})
+
+}
+
+func testInteractive(t *testing.T, bin string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(
+		ctx,
+		bin,
+	)
+
+	cmdTest := New(cmd)
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+	assert.Equal(t, "This is a test program\n", cmdTest.ReadLine())
+	assert.Equal(t, "What's your name?: ", cmdTest.ReadLine())
+	cmdTest.Write("Kamil\n")
+	assert.Equal(t, "Hi Kamil, it's nice to meet you!\n", cmdTest.ReadLine())
+
+	err := cmd.Wait()
+	assert.Nil(t, err)
+
+	assert.Equal(t, []string{}, cmdTest.Output()) // No more data
+}

--- a/test/cmdtest/examplecmd/main.go
+++ b/test/cmdtest/examplecmd/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("This is a test program")
+	fmt.Print("What's your name?: ")
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		fmt.Println("error reading line")
+	}
+
+	// remove '\n'
+	name := line[:len(line)-1]
+
+	fmt.Printf("Hi %s, it's nice to meet you!\n", name)
+}

--- a/test/fakeapi/fakeapi.go
+++ b/test/fakeapi/fakeapi.go
@@ -1,0 +1,47 @@
+/*
+   Copyright (c) 2016, Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package fakeapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+type FakeApi struct {
+	testServer *httptest.Server
+	serveMux   *http.ServeMux
+}
+
+func New() *FakeApi {
+	fakeApi := &FakeApi{}
+	fakeApi.serveMux = http.NewServeMux()
+	fakeApi.testServer = httptest.NewServer(fakeApi.serveMux)
+	return fakeApi
+}
+
+func (f *FakeApi) Close() {
+	f.testServer.Close()
+}
+
+func (f *FakeApi) URL() string {
+	return f.testServer.URL
+}
+
+func (f *FakeApi) Append(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	f.serveMux.HandleFunc(pattern, handler)
+}

--- a/test/fakeapi/handlers.go
+++ b/test/fakeapi/handlers.go
@@ -1,0 +1,129 @@
+/*
+   Copyright (c) 2014-2015, Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package fakeapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/percona/pmm/proto"
+)
+
+func (f *FakeApi) AppendRoot() {
+	f.Append("/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(600)
+		}
+	})
+}
+
+func (f *FakeApi) AppendPing() {
+	f.Append("/ping", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(600)
+		}
+	})
+}
+
+func (f *FakeApi) AppendQanAPIInstancesId(id string, protoInstance *proto.Instance) {
+	f.Append(fmt.Sprintf("/qan-api/instances/%s", id), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(&protoInstance)
+		w.Write(data)
+	})
+}
+
+func (f *FakeApi) AppendConsulV1StatusLeader(xRemoteIP string) {
+	f.Append("/v1/status/leader", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("X-Remote-IP", xRemoteIP)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("\"127.0.0.1:8300\""))
+	})
+}
+
+func (f *FakeApi) AppendConsulV1CatalogNode() {
+	f.Append("/v1/catalog/node/", func(w http.ResponseWriter, r *http.Request) {
+		out := api.CatalogNode{
+			Node: &api.Node{},
+		}
+		data, _ := json.Marshal(out)
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	})
+}
+
+func (f *FakeApi) AppendConsulV1CatalogService() {
+	f.Append("/v1/catalog/service/", func(w http.ResponseWriter, r *http.Request) {
+		out := []api.CatalogService{}
+		data, _ := json.Marshal(out)
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	})
+}
+
+func (f *FakeApi) AppendConsulV1CatalogRegister() {
+	f.Append("/v1/catalog/register", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PUT":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(600)
+		}
+	})
+}
+
+func (f *FakeApi) AppendQanAPIInstances(protoInstances []*proto.Instance) {
+	instances := map[string]*proto.Instance{}
+	for i := range protoInstances {
+		instances[protoInstances[i].Subsystem] = protoInstances[i]
+	}
+	f.Append("/qan-api/instances/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PUT":
+			w.WriteHeader(http.StatusNoContent)
+		case "GET":
+			t := r.URL.Query().Get("type")
+			w.WriteHeader(http.StatusOK)
+			data, _ := json.Marshal(instances[t])
+			w.Write(data)
+		default:
+			w.WriteHeader(600)
+		}
+
+	})
+}
+
+func (f *FakeApi) AppendQanAPIAgents(id string) {
+	f.Append(fmt.Sprintf("/qan-api/agents/%s/cmd", id), func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PUT":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(600)
+		}
+
+	})
+}


### PR DESCRIPTION
This allows me to test `pmm-admin` as a black box (https://en.wikipedia.org/wiki/Functional_testing). I need this for other PRs.

```go
cmd := exec.Command(
	data.bin,
	"config",
	"--server",
	u.Host,
)

cmdTest := cmdtest.New(cmd)
if err := cmd.Start(); err != nil {
	log.Fatal(err)
}
err := cmd.Wait()
assert.Nil(t, err)

// sanity check that version number was changed with ldflag for this test build
assert.Equal(t, "OK, PMM server is alive.\n", cmdTest.ReadLine())
assert.Equal(t, "\n", cmdTest.ReadLine())
assert.Equal(t, fmt.Sprintf("%-15s | %s \n", "PMM Server", u.Host), cmdTest.ReadLine())
assert.Equal(t, fmt.Sprintf("%-15s | %s\n", "Client Name", clientName), cmdTest.ReadLine())
assert.Equal(t, fmt.Sprintf("%-15s | %s \n", "Client Address", clientAddress), cmdTest.ReadLine())

assert.Equal(t, "", cmdTest.ReadLine()) // No more data
```