### PR TITLE
PMM-2408 Added validation to prevent submit annotation with empty des…

### DIFF
--- a/pmm/annotation.go
+++ b/pmm/annotation.go
@@ -19,6 +19,7 @@ package pmm
 
 import (
 	"context"
+	"errors"
 	"regexp"
 
 	"github.com/percona/pmm-client/pmm/managed"
@@ -26,6 +27,9 @@ import (
 
 // AddAnnotation posts annotation to managed.
 func (a *Admin) AddAnnotation(ctx context.Context, text string, tags string) error {
+	if text == "" {
+		return errors.New("Failed to save annotation. Empty annotation is not allowed.")
+	}
 	return a.managedAPI.AnnotationCreate(ctx, &managed.APIAnnotationCreateRequest{
 		Text: text,
 		// split by comma and trim spaces if they were after comma

--- a/pmm/annotation.go
+++ b/pmm/annotation.go
@@ -28,7 +28,7 @@ import (
 // AddAnnotation posts annotation to managed.
 func (a *Admin) AddAnnotation(ctx context.Context, text string, tags string) error {
 	if text == "" {
-		return errors.New("Failed to save annotation. Empty annotation is not allowed.")
+		return errors.New("failed to save annotation (empty annotation is not allowed)")
 	}
 	return a.managedAPI.AnnotationCreate(ctx, &managed.APIAnnotationCreateRequest{
 		Text: text,

--- a/pmm/annotation_test.go
+++ b/pmm/annotation_test.go
@@ -55,4 +55,7 @@ func TestAdmin_AddAnnotation(t *testing.T) {
 
 	err := admin.AddAnnotation(context.TODO(), "Description", "tag1, tag2")
 	assert.Nil(t, err)
+
+	err = admin.AddAnnotation(context.TODO(), "", "tag1, tag2")
+	assert.Equal(t, "Failed to save annotation. Empty annotation is not allowed.", err.Error())
 }

--- a/pmm/annotation_test.go
+++ b/pmm/annotation_test.go
@@ -57,5 +57,5 @@ func TestAdmin_AddAnnotation(t *testing.T) {
 	assert.Nil(t, err)
 
 	err = admin.AddAnnotation(context.TODO(), "", "tag1, tag2")
-	assert.Equal(t, "Failed to save annotation. Empty annotation is not allowed.", err.Error())
+	assert.Equal(t, "failed to save annotation (empty annotation is not allowed)", err.Error())
 }


### PR DESCRIPTION
…cription.

Result:
```console
root@c4ee925b37aa:/# pmm-admin annotate ""
Your annotation could not be posted. Error message we received was:
 failed to save annotation (empty annotation is not allowed)
root@c4ee925b37aa:/# 

```