### PR TITLE
[PMM-2515] Now the annotation joins all args as description.

### DIFF
--- a/pmm-admin.go
+++ b/pmm-admin.go
@@ -187,11 +187,11 @@ run 'pmm-admin repair' to remove orphaned services. Otherwise, please reinstall 
 		Long:    "Publish Application Events as Annotations to PMM Server.",
 		Example: `  pmm-admin annotate "Application deploy v1.2" --tags "UI, v1.2"`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 1 {
+			if len(args) < 1 {
 				fmt.Println("Description of annotation is required")
 				os.Exit(1)
 			}
-			if err := admin.AddAnnotation(context.TODO(), args[0], flagATags); err != nil {
+			if err := admin.AddAnnotation(context.TODO(), strings.Join(args, " "), flagATags); err != nil {
 				fmt.Println("Your annotation could not be posted. Error message we received was:\n", err)
 				os.Exit(1)
 			}


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-2515

pmm-admin annotate - more than 1 annotation

```
root@9b2fcf1a0fb3:/# pmm-admin annotate "Hello" "world"
Your annotation was successfully posted.
root@9b2fcf1a0fb3:/# pmm-admin annotate
Description of annotation is required
root@9b2fcf1a0fb3:/# pmm-admin annotate Hello world again  
Your annotation was successfully posted.
root@9b2fcf1a0fb3:/# pmm-admin annotate Hello world one more time --tags="tag1,tag2"
Your annotation was successfully posted.
```

<img width="600" alt="image" src="https://user-images.githubusercontent.com/2538638/40041867-27ca92e8-5828-11e8-88b8-2e9929a09916.png">
