### PR TITLE
PMM-5094 Removed clickhouse exp from pmm-client

### DIFF
--- a/build/deb/files
+++ b/build/deb/files
@@ -14,7 +14,6 @@ install -m 0755 bin/mysqld_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client
 install -m 0755 bin/postgres_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
 install -m 0755 bin/mongodb_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
 install -m 0755 bin/proxysql_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
-install -m 0755 bin/clickhouse_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
 install -m 0755 bin/pt-summary $RPM_BUILD_ROOT/usr/local/percona/qan-agent/bin/
 install -m 0755 bin/pt-mysql-summary $RPM_BUILD_ROOT/usr/local/percona/qan-agent/bin/
 install -m 0755 bin/pt-mongodb-summary $RPM_BUILD_ROOT/usr/local/percona/qan-agent/bin/

--- a/build/deb/install
+++ b/build/deb/install
@@ -4,7 +4,6 @@ mysqld_exporter /usr/local/percona/pmm-client/
 postgres_exporter /usr/local/percona/pmm-client/
 mongodb_exporter /usr/local/percona/pmm-client/
 proxysql_exporter /usr/local/percona/pmm-client/
-clickhouse_exporter /usr/local/percona/pmm-client/
 pt-summary /usr/local/percona/qan-agent/bin/
 pt-mysql-summary /usr/local/percona/qan-agent/bin/
 pt-mongodb-summary /usr/local/percona/qan-agent/bin/

--- a/build/deb/rules
+++ b/build/deb/rules
@@ -47,7 +47,6 @@ override_dh_auto_install:
 	cp -f distro/postgres_exporter $(TMP)/postgres_exporter
 	cp -f distro/mongodb_exporter $(TMP)/mongodb_exporter
 	cp -f distro/proxysql_exporter $(TMP)/proxysql_exporter
-	cp -f distro/clickhouse_exporter $(TMP)/clickhouse_exporter
 	cp -f distro/percona-qan-agent $(TMP)/percona-qan-agent
 	cp -f distro/pt-summary $(TMP)/pt-summary
 	cp -f distro/pt-mysql-summary $(TMP)/pt-mysql-summary

--- a/build/rpm.spec
+++ b/build/rpm.spec
@@ -40,7 +40,6 @@ install -m 0755 bin/mysqld_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client
 install -m 0755 bin/postgres_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
 install -m 0755 bin/mongodb_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
 install -m 0755 bin/proxysql_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
-install -m 0755 bin/clickhouse_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
 install -m 0755 bin/pt-summary $RPM_BUILD_ROOT/usr/local/percona/qan-agent/bin/
 install -m 0755 bin/pt-mysql-summary $RPM_BUILD_ROOT/usr/local/percona/qan-agent/bin/
 install -m 0755 bin/pt-mongodb-summary $RPM_BUILD_ROOT/usr/local/percona/qan-agent/bin/

--- a/scripts/build
+++ b/scripts/build
@@ -70,14 +70,6 @@ cd $GOPATH/src/github.com/percona/proxysql_exporter
 make
 mv ./proxysql_exporter $SOURCE_DIR/distro/bin/proxysql_exporter
 
-printf "Building clickhouse_exporter...\t"
-cd $GOPATH/src/github.com/f1yegor/clickhouse_exporter
-make init
-cd $GOPATH
-go build ./src/github.com/f1yegor/clickhouse_exporter
-mv ./clickhouse_exporter $SOURCE_DIR/distro/bin/clickhouse_exporter
-
-
 # Prepare tarball dir.
 cd $SOURCE_DIR
 cp CHANGELOG.md VERSION LICENSE scripts/install scripts/uninstall $PKG_DIR


### PR DESCRIPTION
Clickhouse exporter is not part of pmm-client 1.x, it is being built only as part of pmm-server