### PR TITLE
PMM-5094 [1.x] Remove clickhouse_exporter references.

### DIFF
--- a/build/deb/files
+++ b/build/deb/files
@@ -14,7 +14,6 @@ install -m 0755 bin/mysqld_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client
 install -m 0755 bin/postgres_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
 install -m 0755 bin/mongodb_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
 install -m 0755 bin/proxysql_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
-install -m 0755 bin/clickhouse_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
 install -m 0755 bin/pt-summary $RPM_BUILD_ROOT/usr/local/percona/qan-agent/bin/
 install -m 0755 bin/pt-mysql-summary $RPM_BUILD_ROOT/usr/local/percona/qan-agent/bin/
 install -m 0755 bin/pt-mongodb-summary $RPM_BUILD_ROOT/usr/local/percona/qan-agent/bin/

--- a/build/deb/install
+++ b/build/deb/install
@@ -4,7 +4,6 @@ mysqld_exporter /usr/local/percona/pmm-client/
 postgres_exporter /usr/local/percona/pmm-client/
 mongodb_exporter /usr/local/percona/pmm-client/
 proxysql_exporter /usr/local/percona/pmm-client/
-clickhouse_exporter /usr/local/percona/pmm-client/
 pt-summary /usr/local/percona/qan-agent/bin/
 pt-mysql-summary /usr/local/percona/qan-agent/bin/
 pt-mongodb-summary /usr/local/percona/qan-agent/bin/

--- a/build/deb/rules
+++ b/build/deb/rules
@@ -47,7 +47,6 @@ override_dh_auto_install:
 	cp -f distro/postgres_exporter $(TMP)/postgres_exporter
 	cp -f distro/mongodb_exporter $(TMP)/mongodb_exporter
 	cp -f distro/proxysql_exporter $(TMP)/proxysql_exporter
-	cp -f distro/clickhouse_exporter $(TMP)/clickhouse_exporter
 	cp -f distro/percona-qan-agent $(TMP)/percona-qan-agent
 	cp -f distro/pt-summary $(TMP)/pt-summary
 	cp -f distro/pt-mysql-summary $(TMP)/pt-mysql-summary

--- a/build/rpm.spec
+++ b/build/rpm.spec
@@ -40,7 +40,6 @@ install -m 0755 bin/mysqld_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client
 install -m 0755 bin/postgres_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
 install -m 0755 bin/mongodb_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
 install -m 0755 bin/proxysql_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
-install -m 0755 bin/clickhouse_exporter $RPM_BUILD_ROOT/usr/local/percona/pmm-client/
 install -m 0755 bin/pt-summary $RPM_BUILD_ROOT/usr/local/percona/qan-agent/bin/
 install -m 0755 bin/pt-mysql-summary $RPM_BUILD_ROOT/usr/local/percona/qan-agent/bin/
 install -m 0755 bin/pt-mongodb-summary $RPM_BUILD_ROOT/usr/local/percona/qan-agent/bin/

--- a/scripts/build
+++ b/scripts/build
@@ -70,13 +70,6 @@ cd $GOPATH/src/github.com/percona/proxysql_exporter
 make
 mv ./proxysql_exporter $SOURCE_DIR/distro/bin/proxysql_exporter
 
-printf "Building clickhouse_exporter...\t"
-cd $GOPATH/src/github.com/f1yegor/clickhouse_exporter
-make init
-cd $GOPATH
-go build ./src/github.com/f1yegor/clickhouse_exporter
-mv ./clickhouse_exporter $SOURCE_DIR/distro/bin/clickhouse_exporter
-
 
 # Prepare tarball dir.
 cd $SOURCE_DIR

--- a/scripts/install
+++ b/scripts/install
@@ -11,7 +11,7 @@ if [ $(id -u) -ne 0 ]; then
 fi
 
 # Clean up invalid dir created in v1.7.2
-if [ -d "$PMM_DIR/textfile_collector" ]; then 
+if [ -d "$PMM_DIR/textfile_collector" ]; then
    rm -rf $PMM_DIR/textfile_collector
 fi
 
@@ -26,7 +26,6 @@ cp -f bin/mysqld_exporter $PMM_DIR/
 cp -f bin/postgres_exporter $PMM_DIR/
 cp -f bin/mongodb_exporter $PMM_DIR/
 cp -f bin/proxysql_exporter $PMM_DIR/
-cp -f bin/clickhouse_exporter $PMM_DIR/
 cp -f bin/percona-qan-agent $QAN_DIR/bin/
 cp -f bin/percona-qan-agent-installer $QAN_DIR/bin/
 cp -f bin/pt-summary $QAN_DIR/bin/


### PR DESCRIPTION
That PR fixes PMM 1.x Client build.

clickhouse_exporter is not a part of PMM 1.x Client packages. It was originally added at #193 to `PMM-2.0` (that branch should not be in that 1.x repository at all), and #201 somehow [mis-merged](https://github.com/percona/pmm-client/commit/fafa3e17542c53764576eb3adefbcabc9c0ae161) it into `master`. Then #202 reverted changes in `PMM-2.0` branch (again, it should not be there), but `master` is still broken.

https://github.com/Percona-Lab/pmm-submodules/pull/564